### PR TITLE
long overflow

### DIFF
--- a/app/src/main/java/com/skelton/flowcache/cache/DataCacheMemory.kt
+++ b/app/src/main/java/com/skelton/flowcache/cache/DataCacheMemory.kt
@@ -39,7 +39,7 @@ class DataCacheMemory(private val timeProvider: TimeProvider) : DataCache {
                 Duration.between(timeProvider.now(), timeout.time)
             }
             CachePolicy.Timeout.Always -> Duration.ZERO
-            CachePolicy.Timeout.Never -> Duration.ofDays(Long.MAX_VALUE)
+            CachePolicy.Timeout.Never -> ChronoUnit.FOREVER.duration
         }
         val entry = CacheEntry(value, timeProvider.now() + expiryDuration)
         key.log("Setting cache Entry: $entry")


### PR DESCRIPTION
Fix `java.lang.ArithmeticException: long overflow` exceptions, caused by passing `Long.MAX_VALUE` to `Duration.ofDays()`